### PR TITLE
feat: add site pages and blog

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 const links = [
   ['/', 'Home'],
@@ -9,9 +10,15 @@ const links = [
 ];
 
 export default function Navbar() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+
   return (
     <header className="sticky top-0 backdrop-blur z-50 border-b border-gray-200 dark:border-gray-700">
-      <nav className="max-w-5xl mx-auto flex gap-4 p-4">
+      <nav className="max-w-5xl mx-auto flex items-center gap-4 p-4">
         {links.map(([to, label]) => (
           <NavLink
             key={to}
@@ -23,6 +30,12 @@ export default function Navbar() {
             {label}
           </NavLink>
         ))}
+        <button
+          onClick={() => setDark((v) => !v)}
+          className="ml-auto px-2 py-1 text-sm border rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+        >
+          {dark ? '라이트' : '다크'}
+        </button>
       </nav>
     </header>
   );

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,8 +1,43 @@
 export default function About() {
+  const skills = ['JavaScript', 'Python', 'React', 'Tailwind', 'Node.js'];
   return (
-    <section>
-      <h2 className="text-2xl font-bold mb-4">About Me</h2>
-      <p>Turin은 열정적인 중학생 개발자로, 다양한 기술을 배우고 활용하고 있습니다.</p>
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold mb-4">About Me</h2>
+        <p>
+          Turin은 열정적인 중학생 개발자로, 다양한 웹 기술을 배우고 프로젝트에 적용하고 있습니다.
+        </p>
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Skills</h3>
+        <div className="flex flex-wrap gap-2">
+          {skills.map((s) => (
+            <span
+              key={s}
+              className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm"
+            >
+              {s}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Timeline</h3>
+        <ol className="border-l border-gray-300 dark:border-gray-700 ml-2">
+          <li className="pl-4 mb-4">
+            <div className="text-sm text-gray-500">2023</div>
+            <p className="font-medium">프로그래밍 시작</p>
+          </li>
+          <li className="pl-4 mb-4">
+            <div className="text-sm text-gray-500">2024</div>
+            <p className="font-medium">첫 디스코드 봇 배포</p>
+          </li>
+          <li className="pl-4">
+            <div className="text-sm text-gray-500">2025</div>
+            <p className="font-medium">포트폴리오 사이트 공개</p>
+          </li>
+        </ol>
+      </div>
     </section>
   );
 }

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,8 +1,51 @@
-export default function Blog() {
+import { Routes, Route, Link, useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+
+const rawPosts = import.meta.glob('../posts/*.md', { as: 'raw', eager: true });
+
+const summaries = Object.entries(rawPosts).map(([path, content]) => {
+  const slug = path.split('/').pop().replace('.md', '');
+  const lines = content.split('\n');
+  const title = lines[0].replace(/^#\s+/, '');
+  const date = lines[2]?.replace(/^>\s*/, '');
+  return { slug, title, date };
+});
+
+function PostList() {
   return (
     <section>
       <h2 className="text-2xl font-bold mb-4">Blog</h2>
-      <p>블로그 포스트 목록이 여기에 표시됩니다.</p>
+      <ul className="space-y-4">
+        {summaries.map((post) => (
+          <li key={post.slug} className="border-b pb-2">
+            <Link to={post.slug} className="text-xl hover:underline">
+              {post.title}
+            </Link>
+            <p className="text-sm text-gray-500">{post.date}</p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }
+
+function Post() {
+  const { slug } = useParams();
+  const content = rawPosts[`../posts/${slug}.md`];
+  if (!content) return <p>포스트를 찾을 수 없습니다.</p>;
+  return (
+    <article className="space-y-4">
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </article>
+  );
+}
+
+export default function Blog() {
+  return (
+    <Routes>
+      <Route index element={<PostList />} />
+      <Route path=":slug" element={<Post />} />
+    </Routes>
+  );
+}
+

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,8 +1,25 @@
 export default function Contact() {
+  const links = [
+    { href: 'https://github.com/turin-dev', label: 'GitHub' },
+    { href: 'mailto:turin@example.com', label: 'Email' },
+    { href: 'https://discordapp.com/users/turin', label: 'Discord' },
+  ];
   return (
     <section>
       <h2 className="text-2xl font-bold mb-4">Contact</h2>
-      <p>GitHub, Email, Discord 링크를 통해 연락해주세요.</p>
+      <div className="flex gap-4">
+        {links.map((l) => (
+          <a
+            key={l.label}
+            href={l.href}
+            target="_blank"
+            rel="noreferrer"
+            className="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600"
+          >
+            {l.label}
+          </a>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,13 @@
 export default function Home() {
   return (
-    <section className="text-center mt-10">
+    <section className="text-center mt-10 space-y-4">
+      <img
+        src="https://github.com/turin-dev.png"
+        alt="Turin 프로필"
+        className="w-32 h-32 rounded-full mx-auto"
+      />
       <h1 className="text-3xl font-bold">안녕하세요, Turin입니다 👋</h1>
-      <p className="mt-4">중학생 개발자 포트폴리오 사이트에 오신 걸 환영합니다!</p>
+      <p className="mt-2">중학생 개발자, 새로운 도전을 즐깁니다.</p>
     </section>
   );
 }

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,8 +1,15 @@
+import projects from '../data/projects';
+import ProjectCard from '../components/ProjectCard';
+
 export default function Portfolio() {
   return (
     <section>
       <h2 className="text-2xl font-bold mb-4">Portfolio</h2>
-      <p>포트폴리오 프로젝트들이 여기에 표시됩니다.</p>
+      <div className="grid gap-6 sm:grid-cols-2">
+        {projects.map((p) => (
+          <ProjectCard key={p.title} project={p} />
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add navbar dark mode toggle and core pages
- render markdown blog posts with React Router
- list portfolio projects and contact links

## Testing
- `npm run build` (fails: vite Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_688f1f0d92f48331abe0be2277815a73