### PR TITLE
Add Flask post viewer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+import time
+from flask import Flask, render_template, abort
+import psycopg2
+from psycopg2.extras import RealDictCursor
+import markdown2
+
+DATABASE_URL = "postgresql://postgres:NwanzjapZJAqvQiMsNiBwGUQHAJqvzeF@postgres-en2t.railway.internal:5432/railway"
+
+app = Flask(__name__)
+
+def get_posts():
+    """Fetch all posts with one retry on failure."""
+    for attempt in range(2):
+        try:
+            conn = psycopg2.connect(DATABASE_URL)
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT id, date, name, detail FROM post ORDER BY date DESC"
+                )
+                return cur.fetchall()
+        except Exception:
+            if attempt == 0:
+                time.sleep(5)
+            else:
+                return []
+        finally:
+            if 'conn' in locals() and conn:
+                conn.close()
+
+@app.route('/')
+def index():
+    posts = get_posts()
+    return render_template('post_list.html', posts=posts)
+
+@app.route('/post/<int:post_id>')
+def post_detail(post_id):
+    try:
+        conn = psycopg2.connect(DATABASE_URL)
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, date, name, detail FROM post WHERE id = %s", (post_id,)
+            )
+            post = cur.fetchone()
+    except Exception:
+        post = None
+    finally:
+        if 'conn' in locals() and conn:
+            conn.close()
+
+    if not post:
+        abort(404)
+
+    post['detail'] = markdown2.markdown(post['detail'])
+    return render_template('post_detail.html', post=post)
+
+if __name__ == '__main__':
+    app.run()

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+    <title>{{ post.name }}</title>
+</head>
+<body>
+    <h1>{{ post.name }}</h1>
+    <p>{{ post.date }}</p>
+    <div>{{ post.detail|safe }}</div>
+</body>
+</html>

--- a/templates/post_list.html
+++ b/templates/post_list.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+    <title>Posts</title>
+</head>
+<body>
+    <h1>Posts</h1>
+    <ul>
+    {% for post in posts %}
+        <li><a href="{{ url_for('post_detail', post_id=post.id) }}">{{ post.name }}</a> - {{ post.date }}</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app connecting to PostgreSQL and listing posts
- support detailed post view with Markdown rendering

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902f0f82388331bf3f0729c8ea6a43