### PR TITLE
Add simple post feature with Express and PostgreSQL

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS post (
+  date TEXT,
+  name TEXT,
+  detail TEXT
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "my_homepage",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "pg": "^8.11.0"
       }
@@ -156,18 +155,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "my_homepage",
   "version": "1.0.0",
-  "description": "Minimal posts feature",
-  "main": "backend/server.js",
+  "type": "module",
   "scripts": {
-    "start": "node backend/server.js",
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "pg": "^8.11.0"
   }

--- a/post.html
+++ b/post.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>Posts</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+  <h1>Posts</h1>
+  <ul id="list"></ul>
+  <h2 id="title"></h2>
+  <p id="time"></p>
+  <div id="content"></div>
+  <script type="module">
+    const list = document.getElementById('list');
+    const title = document.getElementById('title');
+    const time = document.getElementById('time');
+    const content = document.getElementById('content');
+
+    const wait = ms => new Promise(r => setTimeout(r, ms));
+    async function fetchWithRetry(url, opts, retry = 5) {
+      for (let i = 0; i < retry; i++) {
+        try {
+          const res = await fetch(url, opts);
+          if (!res.ok) throw new Error('net');
+          return await res.json();
+        } catch (e) {
+          if (i === retry - 1) throw e;
+          await wait(5000);
+        }
+      }
+    }
+
+    const formatDate = s => {
+      const [d, t] = s.split('/');
+      const [h, m] = t.split('.');
+      return `${d} ${h}:${m}`;
+    };
+
+    async function loadPosts() {
+      try {
+        const posts = await fetchWithRetry('/posts');
+        list.innerHTML = '';
+        posts.forEach((p, i) => {
+          const li = document.createElement('li');
+          li.textContent = `${p.name} (${formatDate(p.date)})`;
+          li.onclick = () => showPost(i + 1);
+          list.appendChild(li);
+        });
+      } catch (e) {
+        list.textContent = '로드 실패';
+      }
+    }
+
+    async function showPost(id) {
+      try {
+        const p = await fetchWithRetry(`/post/${id}`);
+        title.textContent = p.name;
+        time.textContent = formatDate(p.date);
+        content.innerHTML = marked.parse(p.detail);
+      } catch (e) {
+        content.textContent = '로드 실패';
+      }
+    }
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import { Pool } from 'pg';
+
+const conn = 'postgresql://postgres:NwanzjapZJAqvQiMsNiBwGUQHAJqvzeF@postgres-en2t.railway.internal:5432/railway';
+const pool = new Pool({ connectionString: conn });
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+async function initDB() {
+  while (true) {
+    try {
+      await pool.query('SELECT 1');
+      await pool.query('CREATE TABLE IF NOT EXISTS post (date TEXT, name TEXT, detail TEXT)');
+      break;
+    } catch (e) {
+      console.error('DB connect fail', e.message);
+      await wait(5000);
+    }
+  }
+}
+
+await initDB();
+
+const app = express();
+
+app.get('/posts', async (req, res) => {
+  for (let i = 0; i < 5; i++) {
+    try {
+      const { rows } = await pool.query('SELECT * FROM post ORDER BY date DESC');
+      return res.json(rows);
+    } catch (e) {
+      if (i === 4) return res.status(503).json({ error: 'db error' });
+      await wait(5000);
+    }
+  }
+});
+
+app.get('/post/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id < 1) return res.sendStatus(400);
+  try {
+    const { rows } = await pool.query(`
+      WITH numbered AS (
+        SELECT row_number() OVER (ORDER BY date DESC) AS id, date, name, detail
+        FROM post
+      )
+      SELECT date, name, detail FROM numbered WHERE id = $1
+    `, [id]);
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (e) {
+    res.status(503).json({ error: 'db error' });
+  }
+});
+
+app.listen(3000, () => console.log('server running on 3000'));


### PR DESCRIPTION
## Summary
- add Express server with PostgreSQL connection retry and post APIs
- add HTML client using fetch and marked
- add SQL schema for `post` table

## Testing
- `npm install`
- `npm test`
- `node server.js` (fails: getaddrinfo ENOTFOUND)

------
https://chatgpt.com/codex/tasks/task_e_68903101fdf88331aa4c1477a8f84780